### PR TITLE
Removing giveaways.json from .gitignore file will fix the issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 .DS_Store
 package-lock.json
-giveaways.json


### PR DESCRIPTION
alot of people having issues with manager this is because our `giveaways.json` file is hidden and after some time it will start corrupt and make's the manager to not get ready. This same problem has cause with me my bot is in total of 200+ server's and this problem is start causing then i remember that why not i check giveaways.json file and when i see it's not there then remove it from .gitignore file and delete the file restart the bot and this bot it's working perfectly fine.