### PR TITLE
Correction d'un bug sur la commande end

### DIFF
--- a/commands/end-giveaway.js
+++ b/commands/end-giveaway.js
@@ -21,7 +21,7 @@ exports.run = async (client, message, args) => {
 
     // If no giveaway was found
     if(!giveaway){
-        return message.channel('Unable to find a giveaway for `'+args.join(' ')+'`');
+        return message.channel.send('Unable to find a giveaway for `'+ args.join(' ') + '`.');
     }
 
     // Edit the giveaway


### PR DESCRIPTION
Si je met l'ID d'un concours incorrect (ex : AAA). Il n'envoie rien et renvoie une erreur car il manque la fonction send.